### PR TITLE
Abstract environment from stream under test

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "eslint": "^2.8.0",
     "mkdirp": "^0.5.1",
     "mocha": "^2.5.3",
-    "most": "*"
+    "most": "*",
+    "most-subject": "^4.1.3",
+    "rimraf": "^2.5.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "mkdirp": "^0.5.1",
     "mocha": "^2.5.3",
     "most": "*",
-    "most-subject": "^4.1.3",
     "rimraf": "^2.5.4"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,1 @@
-export {run} from './run';
+export * from './run';

--- a/src/run/index.js
+++ b/src/run/index.js
@@ -48,6 +48,10 @@ export class TestEnvironment {
     });
   }
 
+  track( ...streams ) {
+    streams.forEach( s => this._cache(s) );
+    return this;
+  }
 
   _cache( stream ) {
     let cache = this._cacheMap.get( stream );

--- a/test/shared-env.js
+++ b/test/shared-env.js
@@ -1,0 +1,114 @@
+import * as most from 'most';
+import { TestEnvironment } from '../src';
+import assert from 'assert';
+
+const lazilyPeriodic = t => most.periodic(t)
+                                .concatMap( () => most.just(1).delay(t) )
+                                .timestamp()
+                                .map( ts => ts.time );
+
+describe( 'class TestEnvironment', () => {
+
+    it( 'should comply to API', () => {
+        const env = new TestEnvironment();
+        assert.equal( typeof env.now, 'number' );
+        assert.equal( typeof env.tick, 'function' );
+        assert.equal( typeof env.collect, 'function' );
+        assert.equal( typeof env.results, 'function' );
+        assert.equal( typeof env.reset, 'function' );
+    });
+
+    it( '.tick() increments .now', () => {
+        const env = new TestEnvironment();
+        assert.strictEqual( env.now, 0 );
+        return env.tick( 2 )
+                  .collect( most.empty() )
+                  .then( () => {
+                      assert.strictEqual( env.now, 2 );
+                  });
+    });
+
+    it( '.reset() restarts the time', () => {
+        const env = new TestEnvironment();
+        assert.strictEqual( env.now, 0 );
+        return env.tick( 2 )
+                  .collect( most.empty() )
+                  .then( () => {
+                      assert.strictEqual( env.now, 2 );
+                      return env.reset();
+                  }).then( () => {
+                      assert.strictEqual( env.now, 0 );
+                  });
+    });
+
+    it( 'should emit the events expected with the specified time interval', () => {
+        const env = new TestEnvironment();
+        const stream$ = lazilyPeriodic( 2 );
+        return env.tick( 2 )
+                  .collect( stream$ )
+                  .then( ({ events }) => {
+                      assert.deepEqual( events, [2] );
+                      return env.tick().collect( stream$ );
+                  })
+                  .then( ({ events }) => {
+                      assert.deepEqual( events, [] );
+                      return env.tick( 5 ).collect( stream$ );
+                  })
+                  .then( ({ events }) => {
+                      assert.deepEqual( events, [4, 6, 8] );
+                  });
+    });
+
+    describe( 'shared stream', () => {
+
+        describe( 'without reset()', () => {
+
+            const env = new TestEnvironment();
+            const _ = undefined; // dummy value
+
+            const stream$ = lazilyPeriodic( 2 );
+            
+            it( 'should emit the events expected with the specified time interval', () => {
+                return env.tick( 5 )
+                          .collect( stream$ )
+                          .then( ({ events }) => {
+                              assert.deepEqual( events, [2, 4] );
+                          });
+            });
+
+            it( 'should conflict with previous test', () => {
+                return env.tick( 5 )
+                          .collect( stream$ )
+                          .then( ({ events }) => {
+                              assert.deepEqual( events, [6, 8, 10] );
+                          });
+            });
+        });
+
+        describe( 'with reset()', () => {
+
+            const env = new TestEnvironment();
+
+            afterEach( () => env.reset() );
+
+            const stream$ = lazilyPeriodic( 1 );
+            
+            it( 'should emit the events expected with the specified time interval', () => {
+                return env.tick( 5 )
+                          .collect( stream$ )
+                          .then( ({ events }) => {
+                              assert.deepEqual( events, [1, 2, 3, 4, 5] );
+                          });
+            });
+
+            it( 'should emit the same events with the same timestamps', () => {
+                return env.tick( 5 )
+                          .collect( stream$ )
+                          .then( ({ events }) => {
+                              assert.deepEqual( events, [1, 2, 3, 4, 5] );
+                          });
+            });
+        });  
+    })
+});
+

--- a/test/shared-env.js
+++ b/test/shared-env.js
@@ -132,8 +132,7 @@ describe( 'class TestEnvironment', () => {
         const delayed$ = stream$.delay( 1 ).timestamp().map( ts => ts.time );
 
         it( 'should emit events at both stages', () => {
-            env.collect( stream$ );
-            env.collect( delayed$ );
+            env.track( stream$, delayed$ );
             return env.tick( 4 ).collect( stream$ )
                       .then( ({ events }) => {
                           assert.deepEqual( events, [2, 4] );
@@ -144,9 +143,8 @@ describe( 'class TestEnvironment', () => {
                       });
         });
 
-        it( 'will not emit events at both stages without observing first', () => {
-            // env.collect( stream$ );
-            // env.collect( delayed$ );
+        it( 'will not emit events at both stages without calling .track() first', () => {
+            // env.track( stream$, delayed$ );
             return env.tick( 4 ).collect( stream$ )
                       .then( ({ events }) => {
                           assert.deepEqual( events, [2, 4] );
@@ -161,8 +159,7 @@ describe( 'class TestEnvironment', () => {
             const LONG_TIME = 30000;
             const stream$ = lazilyPeriodic( LONG_TIME );
             const delayed$ = stream$.delay( LONG_TIME ).timestamp().map( ts => ts.time );
-            env.collect( stream$ );
-            env.collect( delayed$ );
+            env.track( stream$, delayed$ );
             return env.tick( LONG_TIME * 2 ).collect( stream$ )
                       .then( ({ events }) => {
                           assert.deepEqual( events, [LONG_TIME, LONG_TIME * 2] );

--- a/test/shared-env.js
+++ b/test/shared-env.js
@@ -91,13 +91,13 @@ describe( 'class TestEnvironment', () => {
 
             afterEach( () => env.reset() );
 
-            const stream$ = lazilyPeriodic( 1 );
+            const stream$ = lazilyPeriodic( 2 );
             
             it( 'should emit the events expected with the specified time interval', () => {
                 return env.tick( 5 )
                           .collect( stream$ )
                           .then( ({ events }) => {
-                              assert.deepEqual( events, [1, 2, 3, 4, 5] );
+                              assert.deepEqual( events, [2, 4] );
                           });
             });
 
@@ -105,7 +105,7 @@ describe( 'class TestEnvironment', () => {
                 return env.tick( 5 )
                           .collect( stream$ )
                           .then( ({ events }) => {
-                              assert.deepEqual( events, [1, 2, 3, 4, 5] );
+                              assert.deepEqual( events, [2, 4] );
                           });
             });
         });  

--- a/type-definitions/most-test.d.ts
+++ b/type-definitions/most-test.d.ts
@@ -3,20 +3,58 @@ declare module "most-test" {
 
     import { Stream } from 'most'
 
-    export const run: <T>(stream: Stream<T>) => TestEnvironment<T>;
-
     type Time = Number;
     type Interval = Number;
+ 
+    export class TestEnvironment {
 
-    type TestEnvironment<T> = {
-        tick: (min?: Interval) => Promise<Result<T>>;
-        now: Time;
-        results: Result<T>[];
+        readonly now: Time;
+    //  _sinks: WeakMap<Stream, Sink>;
+    //  _results: WeakMap<Stream, Result[]>;
+
+        constructor();
+
+        tick<T>( ms?: Interval ): this;
+        collect<T>( stream: Stream<T> ): Promise<Result<T>>;
+        results<T>( stream: Stream<T> ): Result<T>[];
+        reset(): void;
     }
 
     type Result<T> = {
-        events: Array<T>;
-        end?: true;
+        events: T[];
+        end?: true | { value: T };
         error?: Error;
+    }
+
+    export class BasicTestEnvironment<T> {
+
+        readonly now: Time;
+        readonly results: Result<T>[];
+     // _stream: Stream<T>;
+     // _env: TestEnvironment;
+
+        constructor( stream: Stream<T> );
+
+        tick<T>( ms?: Interval ): Promise<Result<T>>;
+    }
+
+    export function run<T>( stream: Stream<T> ): BasicTestEnvironment<T>;
+
+    class Sink<T> {
+        buckets: Bucket<T>[];
+        t: Time;
+        events: [string, Time, any][];
+        index: number;
+        next( t: Time ): Bucket<T>;
+        event( t: Time, x: T );
+        end( t: Time, x: T );
+        error( t: Time, err: Error );
+    }
+
+    class Bucket<T> {
+        events: T[];
+        end: true | { value: T };
+        error: Error;
+        toObject(): Result<T>;
     }
 }

--- a/type-definitions/most-test.d.ts
+++ b/type-definitions/most-test.d.ts
@@ -9,8 +9,6 @@ declare module "most-test" {
     export class TestEnvironment {
 
         readonly now: Time;
-    //  _sinks: WeakMap<Stream, Sink>;
-    //  _results: WeakMap<Stream, Result[]>;
 
         constructor();
 
@@ -30,8 +28,6 @@ declare module "most-test" {
 
         readonly now: Time;
         readonly results: Result<T>[];
-     // _stream: Stream<T>;
-     // _env: TestEnvironment;
 
         constructor( stream: Stream<T> );
 

--- a/type-definitions/most-test.d.ts
+++ b/type-definitions/most-test.d.ts
@@ -13,6 +13,7 @@ declare module "most-test" {
         constructor();
 
         tick<T>( ms?: Interval ): this;
+        track( ...streams: Stream<any>[] ): this;
         collect<T>( stream: Stream<T> ): Promise<Result<T>>;
         results<T>( stream: Stream<T> ): Result<T>[];
         reset(): void;


### PR DESCRIPTION
This pull request addresses the discussion in #5.

This would be a non-breaking change as the old API still works -- to the extent that the current tests all pass.

This adds an export, `TestEnvironment`, of which the usage can be seen in the tests I've included. As an example:

``` js
import { TestEnvironment } from 'most-test'

const env = new TestEnvironment();

afterEach( () => env.reset() )

it( '1st test', () => {...});
it( '2nd test', () => {...});
it( 'etc', () => {...});
```

Do you have anything you'd like me to change? Do you have an opinion on:
1. Name of `collect()` method
2. Name of `reset()` method -- would `restart()` be better?
3. The spacing of my code -- 4 spaces? I see you used 2 -- would you like me to change mine?
4. Are my tests readable? I feel using `async`/`await` would've improved them drastically but didn't want to mess about with your build environment

NB: I also had to install rimraf as a dev dependency - I guess you have it installed globally
